### PR TITLE
fix(Building): fix GeothermHeater not appearing in build menu

### DIFF
--- a/1.3/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
+++ b/1.3/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
@@ -281,7 +281,7 @@
 	</ThingDef>
 
 
-	<ThingDef ParentName="BasedHeatingMom" DBHLite="true">
+	<ThingDef ParentName="BasedHeatingMom">
 		<designationCategory>Temperature</designationCategory>
 		<defName>GeothermHeater</defName>
 		<label>Geothermal heater</label>

--- a/1.4/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
+++ b/1.4/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
@@ -281,7 +281,7 @@
 	</ThingDef>
 
 
-	<ThingDef ParentName="BasedHeatingMom" DBHLite="true">
+	<ThingDef ParentName="BasedHeatingMom">
 		<designationCategory>Temperature</designationCategory>
 		<defName>GeothermHeater</defName>
 		<label>Geothermal heater</label>

--- a/1.5/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
+++ b/1.5/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
@@ -281,7 +281,7 @@
 	</ThingDef>
 
 
-	<ThingDef ParentName="BasedHeatingMom" DBHLite="true">
+	<ThingDef ParentName="BasedHeatingMom">
 		<designationCategory>Temperature</designationCategory>
 		<defName>GeothermHeater</defName>
 		<label>Geothermal heater</label>


### PR DESCRIPTION
- fix GeothermHeater not appearing in build menu when used with Dubs Bad Hygiene Lite

Hi, I noticed this was the only item with this flag in this repo so I was wondering if its intentional or not. This fixed the game for me when using both mods.

Rimworld: 1.5.4409
Harmony: v2.3.3.0

load order:
https://steamcommunity.com/sharedfiles/filedetails/?id=2570319432
https://steamcommunity.com/sharedfiles/filedetails/?id=2619214952

Please makes changes where you deem necessary or disregard if complete BS. 

Have a good one!